### PR TITLE
YAMLParser: Some minor fixes/additions

### DIFF
--- a/YAMLParser/KnownStuff.cs
+++ b/YAMLParser/KnownStuff.cs
@@ -82,7 +82,9 @@ namespace FauxMessages
         {
             string[] pieces = s.Split('/');
             string package = null;
-            if (pieces.Length == 2)
+            // sometimes, a string can contain the char '/', such as the following line:
+            // string CONTENT_JSON = "application/json"
+            if (pieces.Length == 2 && !s.ToLower().Contains("string"))
             {
                 package = pieces[0];
                 s = pieces[1];

--- a/YAMLParser/KnownStuff.cs
+++ b/YAMLParser/KnownStuff.cs
@@ -84,11 +84,16 @@ namespace FauxMessages
             string package = null;
             // sometimes, a string can contain the char '/', such as the following line:
             // string CONTENT_JSON = "application/json"
-            if (pieces.Length == 2 && !s.ToLower().Contains("string"))
+            if (pieces.Length == 2)
             {
+                if (s.ToLower().Contains("string") && !MsgFile.resolver.ContainsKey(pieces[0]))
+                    goto ResolvingStep;
+                
                 package = pieces[0];
                 s = pieces[1];
             }
+
+            ResolvingStep:
             SingleType st = new SingleType(package, s, extraindent);
             parent.resolve(st);
             WhatItIs(parent, st);

--- a/YAMLParser/MsgFile.cs
+++ b/YAMLParser/MsgFile.cs
@@ -470,7 +470,7 @@ namespace FauxMessages
                     def[i] = def[i].Replace("  ", " ");
                 def[i] = def[i].Replace(" = ", "=");
             }
-            GUTS = GUTS.Replace("$MYMESSAGEDEFINITION", "@\"" + def.Aggregate("", (current, d) => current + (d + "\n")).Trim('\n') + "\"");
+            GUTS = GUTS.Replace("$MYMESSAGEDEFINITION", "@\"" + def.Aggregate("", (current, d) => current + (d + "\n")).Trim('\n').Replace("\"", "\"\"") + "\"");
             GUTS = GUTS.Replace("$MYHASHEADER", HasHeader.ToString().ToLower());
             GUTS = GUTS.Replace("$MYFIELDS", GeneratedDictHelper.Length > 5 ? "{{" + GeneratedDictHelper + "}}" : "()");
             GUTS = GUTS.Replace("$NULLCONSTBODY", "");

--- a/YAMLParser/MsgFileLocator.cs
+++ b/YAMLParser/MsgFileLocator.cs
@@ -170,6 +170,22 @@ namespace YAMLParser
             Console.WriteLine("Skipped " + (msgfiles.Length - (m.Count - mb4)) + " duplicate msgs and " + (srvfiles.Length - (s.Count - sb4)) + " duplicate srvs");
         }
 
+        internal static int priority(string package)
+        {
+            switch (package)
+            {
+                case "std_msgs": return 1;
+                case "geometry_msgs": return 2;
+                case "actionlib_msgs": return 3;
+                default: return 9;
+            }
+        }
+
+        internal static List<MsgFileLocation> sortMessages(List<MsgFileLocation> msgs)
+        {
+            return msgs.OrderBy(m => "" + priority(m.package) + m.package + m.basename).ToList();
+        }
+
         public static void findMessages(List<MsgFileLocation> msgs, List<MsgFileLocation> srvs, List<MsgFileLocation> actionFiles,
             params string[] args)
         {

--- a/YAMLParser/MsgFileLocator.cs
+++ b/YAMLParser/MsgFileLocator.cs
@@ -1,13 +1,36 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using FauxMessages;
 
 namespace YAMLParser
 {
     public class MsgFileLocation
     {
+        // Unicode categories according to https://stackoverflow.com/a/950651/4036588
+        private static readonly UnicodeCategory[] validFirstChars =
+        {
+            UnicodeCategory.UppercaseLetter,    // Lu
+            UnicodeCategory.LowercaseLetter,    // Ll
+            UnicodeCategory.TitlecaseLetter,    // Lt
+            UnicodeCategory.ModifierLetter,     // Lm
+            UnicodeCategory.OtherLetter         // Lo
+            // underscore is also permitted for the first char
+        };
+        private static readonly UnicodeCategory[] otherValidChars =
+        {
+            UnicodeCategory.LetterNumber,           // Nl
+            UnicodeCategory.NonSpacingMark,         // Mn
+            UnicodeCategory.SpacingCombiningMark,   // Mc
+            UnicodeCategory.DecimalDigitNumber,     // Nd
+            UnicodeCategory.ConnectorPunctuation,   // Pc
+            UnicodeCategory.Format                  // Cf
+        };
+        private static readonly UnicodeCategory[] validCSharpChars = validFirstChars.Union(otherValidChars).ToArray();
+
         private static string[] MSG_GEN_FOLDER_NAMES =
         {
             "msg",
@@ -29,6 +52,10 @@ namespace YAMLParser
             string foldername = chunks[chunks.Length - 2];
             if (MSG_GEN_FOLDER_NAMES.Contains(foldername))
                 foldername = chunks[chunks.Length - 3];
+
+            if (!IsValidCSharpIdentifier(foldername))
+                throw new ArgumentException(String.Format("'{0}' from '{1}' is not a compatible C# identifier name\n\tThe package name must conform to C# Language Specifications (refer to this StackOverflow answer: https://stackoverflow.com/a/950651/4036588)\n", foldername, path));
+            
             return foldername;
         }
 
@@ -74,6 +101,37 @@ namespace YAMLParser
         public override string  ToString()
         {
             return string.Format("{0}.{1}", System.IO.Path.Combine(package, basename), extension);
+        }
+
+        public static bool IsValidCSharpIdentifier(string toTest)
+        {
+            if (toTest.Length == 0) // obviously..?
+                return false;
+
+            if (SingleType.IsCSharpKeyword(toTest)) // best to avoid any complications
+                return false;
+
+            char[] letters = toTest.ToCharArray();
+            char first = letters[0];
+
+            if (first != '_' && !validFirstChars.Contains(CharUnicodeInfo.GetUnicodeCategory(first)))
+                return false;
+
+            foreach (char c in letters)
+                if (!validCSharpChars.Contains(CharUnicodeInfo.GetUnicodeCategory(c)))
+                    return false;
+
+            return true;
+
+            // TODO: fix this regex method, replace the above method with it, 
+            // and get rid of the three UnicodeCategory arrays
+            // (regex method found at https://stackoverflow.com/a/1904462/4036588)
+
+            //const string start = @"(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl})";
+            //const string extend = @"(\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\p{Cf})";
+            //Regex ident = new Regex(string.Format("{0}({0}|{1})*", start, extend));
+            //toTest = toTest.Normalize();
+            //return ident.IsMatch(toTest);
         }
     }
 

--- a/YAMLParser/Program.cs
+++ b/YAMLParser/Program.cs
@@ -21,7 +21,7 @@ namespace YAMLParser
         static List<ActionFile> actionFiles = new List<ActionFile>();
         private static ILogger Logger { get; set; }
         const string DEFAULT_OUTPUT_FOLDERNAME = "Messages";
-        static readonly string[] required_packages = {"std_msgs", "geometry_msgs", "actionlib_msgs", "sensor_msgs"};
+        static readonly string[] required_packages = {"std_msgs", "geometry_msgs", /*"actionlib_msgs",*/ "sensor_msgs"};
 
         public static void Main(params string[] args)
         {
@@ -170,7 +170,9 @@ namespace YAMLParser
 
             if (!StdMsgsProcessed()) // may seem obvious, but needed so that all other messages can build...
             {
+                string resolvedPkgs = String.Join(", ", MsgFile.resolver.Keys.OrderBy(x => x.ToString()).ToArray());
                 Console.WriteLine("Missing at least one of the following ROS packages: [\"" + String.Join("\", \"", required_packages) + "\"]. Exiting...");
+                Console.WriteLine("resolver's keys: [" + resolvedPkgs + "]");
                 return;
             }
 

--- a/YAMLParser/Program.cs
+++ b/YAMLParser/Program.cs
@@ -129,6 +129,8 @@ namespace YAMLParser
                 Console.WriteLine("Looking in " + d);
                 MsgFileLocator.findMessages(paths, pathssrv, actionFileLocations, d);
             }
+            // sort paths by priority
+            paths = MsgFileLocator.sortMessages(paths);
 
             // first pass: create all msg files (and register them in static resolver dictionary)
             var baseTypes = MessageTypeRegistry.Default.GetTypeNames().ToList();

--- a/YAMLParser/Program.cs
+++ b/YAMLParser/Program.cs
@@ -21,6 +21,7 @@ namespace YAMLParser
         static List<ActionFile> actionFiles = new List<ActionFile>();
         private static ILogger Logger { get; set; }
         const string DEFAULT_OUTPUT_FOLDERNAME = "Messages";
+        static readonly string[] required_packages = {"std_msgs", "geometry_msgs", "actionlib_msgs", "sensor_msgs"};
 
         public static void Main(params string[] args)
         {
@@ -167,6 +168,12 @@ namespace YAMLParser
             actionFiles = actionFileParser.GenerateRosMessageClasses();
             //var actionFiles = new List<ActionFile>();
 
+            if (!StdMsgsProcessed()) // may seem obvious, but needed so that all other messages can build...
+            {
+                Console.WriteLine("Missing at least one of the following ROS packages: [\"" + String.Join("\", \"", required_packages) + "\"]. Exiting...");
+                return;
+            }
+
             if (paths.Count + pathssrv.Count > 0)
             {
                 MakeTempDir(outputdir);
@@ -186,6 +193,11 @@ namespace YAMLParser
                 Console.WriteLine("Finished. Press enter.");
                 Console.ReadLine();
             }
+        }
+
+        public static bool StdMsgsProcessed()
+        {
+            return required_packages.All(c => MsgFile.resolver.ContainsKey(c));
         }
 
         private static void MakeTempDir(string outputdir)

--- a/YAMLParser/Program.cs
+++ b/YAMLParser/Program.cs
@@ -45,8 +45,10 @@ namespace YAMLParser
                     return 1;
                 }
 
+                List<string> dirs = messageDirectories.Value().Split(',').ToList();
+
                 Program.Run(
-                    messageDirectories.HasValue() ? messageDirectories.Values : null,
+                    messageDirectories.HasValue() ? dirs : null,
                     assemblies.HasValue() ? assemblies.Values : null,
                     outputDirectory.HasValue() ? outputDirectory.Value() : null,
                     interactive.HasValue(),

--- a/YAMLParser/SingleType.cs
+++ b/YAMLParser/SingleType.cs
@@ -109,12 +109,14 @@ namespace FauxMessages
                 otherstuff = " = " + parts[1];
             }
 
-            if (!MsgFileLocation.IsValidCSharpIdentifier(name) && name.Length > 0)
+            if (name == parent.Name.Split(".").Last() || !MsgFileLocation.IsValidCSharpIdentifier(name) && name.Length > 0)
             {
                 if (IsCSharpKeyword(name))
                 {
                     name = "@" + name;
                 }
+                else if (MsgFileLocation.IsValidCSharpIdentifier(name) && name == parent.Name.Split(".").Last())
+                    name = "_" + name;
                 else
                     throw new ArgumentException(String.Format("Variable '{0}' from '{1}' is not a compatible C# identifier name\n\tAll variable names must conform to C# Language Specifications (refer to this StackOverflow answer: https://stackoverflow.com/a/950651/4036588)\n", name, parent.msgFileLocation.Path));
             }
@@ -235,12 +237,14 @@ namespace FauxMessages
                 otherstuff = " = " + parts[1];
             }
 
-            if (!MsgFileLocation.IsValidCSharpIdentifier(name) && name.Length > 0)
+            if (name == parent.Name.Split(".").Last() || !MsgFileLocation.IsValidCSharpIdentifier(name) && name.Length > 0)
             {
                 if (IsCSharpKeyword(name))
                 {
                     name = "@" + name;
                 }
+                else if (MsgFileLocation.IsValidCSharpIdentifier(name) && name == parent.Name.Split(".").Last())
+                    name = "_" + name;
                 else
                     throw new ArgumentException(String.Format("Variable '{0}' from '{1}' is not a compatible C# identifier name\n\tAll variable names must conform to C# Language Specifications (refer to this StackOverflow answer: https://stackoverflow.com/a/950651/4036588)\n", name, parent.msgFileLocation.Path));
             }

--- a/YAMLParser/SingleType.cs
+++ b/YAMLParser/SingleType.cs
@@ -109,9 +109,14 @@ namespace FauxMessages
                 otherstuff = " = " + parts[1];
             }
 
-            if (IsCSharpKeyword(name))
+            if (!MsgFileLocation.IsValidCSharpIdentifier(name) && name.Length > 0)
             {
-                name = "@" + name;
+                if (IsCSharpKeyword(name))
+                {
+                    name = "@" + name;
+                }
+                else
+                    throw new ArgumentException(String.Format("Variable '{0}' from '{1}' is not a compatible C# identifier name\n\tAll variable names must conform to C# Language Specifications (refer to this StackOverflow answer: https://stackoverflow.com/a/950651/4036588)\n", name, parent.msgFileLocation.Path));
             }
 
             for (int i = 2; i < s.Length; i++)
@@ -227,10 +232,17 @@ namespace FauxMessages
                 name = parts[0];
                 otherstuff = " = " + parts[1];
             }
-            if (IsCSharpKeyword(name))
+
+            if (!MsgFileLocation.IsValidCSharpIdentifier(name) && name.Length > 0)
             {
-                name = "@" + name;
+                if (IsCSharpKeyword(name))
+                {
+                    name = "@" + name;
+                }
+                else
+                    throw new ArgumentException(String.Format("Variable '{0}' from '{1}' is not a compatible C# identifier name\n\tAll variable names must conform to C# Language Specifications (refer to this StackOverflow answer: https://stackoverflow.com/a/950651/4036588)\n", name, parent.msgFileLocation.Path));
             }
+
             for (int i = 2; i < backup.Length; i++)
                 otherstuff += " " + backup[i];
             if (otherstuff.Contains('='))

--- a/YAMLParser/SingleType.cs
+++ b/YAMLParser/SingleType.cs
@@ -158,14 +158,16 @@ namespace FauxMessages
                 string prefix = "", suffix = "";
                 if (isconst)
                 {
-                    if (!type.Equals("string", StringComparison.OrdinalIgnoreCase))
-                    {
+                    // why can't strings be constants?
+
+                    //if (!type.Equals("string", StringComparison.OrdinalIgnoreCase))
+                    //{
                         if (KnownStuff.IsPrimitiveType(this))
                             prefix = "const ";
                         else
                             prefix = "static readonly ";
                         wantsconstructor = false;
-                    }
+                    //}
                 }
 
                 string t = KnownStuff.GetNamespacedType(this, type);
@@ -283,10 +285,12 @@ namespace FauxMessages
                 string prefix = "", suffix = "";
                 if (isconst)
                 {
-                    if (!Type.Equals("string", StringComparison.OrdinalIgnoreCase))
-                    {
+                    // why can't strings be constants?
+
+                    //if (!Type.Equals("string", StringComparison.OrdinalIgnoreCase))
+                    //{
                         prefix = "const ";
-                    }
+                    //}
                 }
                 if (otherstuff.Contains('='))
                     if (wantsconstructor)

--- a/YAMLParser/SingleType.cs
+++ b/YAMLParser/SingleType.cs
@@ -11,10 +11,12 @@ namespace FauxMessages
 {
     public class SingleType
     {
-        // TODO extend check to other C# keywords
-        private static readonly string[] CSharpKeywords = { "object", "params", "namespace", "const", "static" };
+        // c# keywords listed on https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/ as of August 1st, 2018
+        private static readonly string[] reserved_keywords = { "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked", "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else", "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for", "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock", "long", "namespace", "new", "null", "object", "operator", "out", "override", "params", "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "using static", "virtual", "void", "volatile", "while" };
+        private static readonly string[] contextual_keywords = { "add", "alias", "ascending", "async", "await", "descending", "dynamic", "from", "get", "global", "group", "into", "join", "let", "nameof", "orderby", "partial", "partial", "remove", "select", "set", "value", "var", "when", "where", "where", "yield" };
+        private static readonly string[] CSharpKeywords = reserved_keywords.Union(contextual_keywords).ToArray();
 
-        private static bool IsCSharpKeyword(string name)
+        public static bool IsCSharpKeyword(string name)
         {
             return CSharpKeywords.Contains(name);
         }


### PR DESCRIPTION
I had [originally](https://github.com/uml-robotics/ROS.NET/pull/50) made a PR on `uml-robotics/ROS.NET`, which included a couple of the commits in this PR. But then I found this fork, and I realized that I was rewriting code that you guys have been rewriting for 2 years! 😝 So this PR includes differences that I found between my own fork and this one. Feel free to cherry-pick any commits you find useful.

**Specific details to follow:**

---
- ##### Commit 1: `YAMLParser: Fix some character escaping for string constants`
- ##### Commit 5: `YAMLParser: (experimentation) Allow strings to be constants`
- ##### Commit 6: `YAMLParser: (attempt to) Fix KnownStuff.WhatItIs bug`
- ##### Commit 7: `Merge code to sort messages by priority`

I'm not sure if it is common practice to use string constants in ROS. But regardless, in its current state, YAMLParser had some issues parsing the following lines in one of my .msg files:
> `string CONTENT_JSON = "application/json"`
> `string CONTENT_STREAM = "application/octet-stream"`

`Commit 1` fixes character escaping for this specific case. But `Commit 1` also breaks resolving for certain messages (for example, the field `filename` in `common_msgs/map_msgs/SaveMap` doesn't resolve its type properly). `Commit 6` fixes this by checking if the left-side of the `/` has been a resolved package name. `Commit 7` (which I merged from `uml-robotics/ROS.NET/master`) sorts the msg file queue by priority, ensuring that `std_msgs`/`geometry_msgs`/`actionlib_msgs` are resolved first, which should hopefully increase the success rate of `Commit 6`.

`Commit 5` comments out some [old code](https://github.com/uml-robotics/ROS.NET/issues/51) that the original author had, which made string constants non-static. I personally prefer string constants to be static, so I commented the lines out. Feel free to skip this commit if not interested.

_Note: I kept strings `const` instead of `static readonly` because I needed them to be processed at compile-time for my own use case._

---
- ##### Commit 2: `YAMLParser: temp workaround to allow multiple arguments in -m`

I think the `CommandLineUtils` library cannot actually support multiple arguments? Either that, or I was too dumb to figure it out. I tried many combinations of commas, quotes, and spaces, but it just kept combining them into one `Value`. I added a temporary workaround, but the bug needs some type of intervention in the future. Perhaps this [updated version](https://github.com/natemcmaster/CommandLineUtils) might work better?

---
- ##### Commit 3: `YAMLParser: expand list of CSharpKeywords`
- ##### Commit 4: `YAMLParser: Add check to ensure pkgs/fields will be valid C# identifiers`

`Commit 3` expands the list of CSharpKeywords to include every keyword listed on Microsoft's website.
`Commit 4` checks the package and field names of every message folder to make sure that they would work as valid identifier names in C#. (For example, if you had a folder named `test-msgs`, or if the name were in a different language, then YAMLParser would still run successfully, but the autogenerated code would not build)

---
- ##### Commit 8: `YAMLParser: Ensure Messages.dll has parsed required ROS packages for lib`
- ##### Commit 9: `YAMLParser: comment out actionlib_msgs from required_packages check`

`Commit 8` ensures that required message packages (`std_msgs`, etc) were included in the args. In instances where they were not included, I have run into 2 distinct issues:

- referenced fields like `Header` cannot resolve in the MD5 hash, so the code autogeneration gets stuck in an infinite loop
- the autogenerated Messages project cannot build because of the following `using` statements from the template:
> `using Messages.geometry_msgs;`
> `using Messages.sensor_msgs;`
> `using Messages.actionlib_msgs;`

`Commit 9` comments out `actionlib_msgs` from the `required_packages` array, because it is not included in `common_msgs`, and the autogenerated code seems to build without it...

---
Thank you!